### PR TITLE
Bump hubot backlog assign to 1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,22 +1,8 @@
 {
   "name": "sushi",
-  "version": "0.0.0",
   "description": "A Hubot for FaithCreates Inc.",
-  "scripts": {
-    "start": "hubot -n sushi -a slack",
-    "test": "mocha --recursive --compilers coffee:coffee-script/register --reporter spec"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git://github.com/faithcreates/sushi.git"
-  },
-  "keywords": [
-    "hubot",
-    "slack",
-    "sushi"
-  ],
+  "version": "0.0.0",
   "author": "FaithCreates Inc.",
-  "license": "MIT",
   "dependencies": {
     "coffee-script": "1.7.1",
     "hubot": "2.9.3",
@@ -48,7 +34,21 @@
     "hubot-mock-adapter": "1.0.0",
     "mocha": "1.20.1",
     "q": "1.0.1",
-    "sinon-chai": "2.5.0",
-    "sinon": "1.10.2"
+    "sinon": "1.10.2",
+    "sinon-chai": "2.5.0"
+  },
+  "keywords": [
+    "hubot",
+    "slack",
+    "sushi"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/faithcreates/sushi.git"
+  },
+  "scripts": {
+    "start": "hubot -n sushi -a slack",
+    "test": "mocha --recursive --compilers coffee:coffee-script/register --reporter spec"
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "hubot": "2.9.3",
     "hubot-auth": "^1.1.2",
     "hubot-backlog-activity": "git://github.com/bouzuya/hubot-backlog-activity.git#2.0.4",
-    "hubot-backlog-assign": "https://github.com/bouzuya/hubot-backlog-assign/archive/1.0.1.tar.gz",
+    "hubot-backlog-assign": "https://github.com/bouzuya/hubot-backlog-assign/archive/1.1.1.tar.gz",
     "hubot-backlog-burndownchart": "git://github.com/bouzuya/hubot-backlog-burndownchart.git#1.0.2",
     "hubot-backlog-issue-preview": "git://github.com/bouzuya/hubot-backlog-issue-preview.git#2.0.1",
     "hubot-backlog-report": "git://github.com/bouzuya/hubot-backlog-report.git#2.0.0",


### PR DESCRIPTION
hubot-backlog-assign のバージョンを 1.1.0 にあげています。

以前は処理中のものに対してレビュー依頼できましたが、処理済みのものにだけレビュー依頼できるようになっています。

また `package.json` に対して fixpack を適用し、整形しました。