### PR TITLE
bump hubot-datadog-graph to 1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "hubot-backlog-status": "https://github.com/bouzuya/hubot-backlog-status/archive/0.1.0.tar.gz",
     "hubot-backlog-summary": "https://github.com/bouzuya/hubot-backlog-summary/archive/0.1.2.tar.gz",
     "hubot-backlog-watch-users": "https://github.com/bouzuya/hubot-backlog-watch-users/archive/1.1.0.tar.gz",
-    "hubot-datadog-graph": "https://github.com/bouzuya/hubot-datadog-graph/archive/1.0.0.tar.gz",
+    "hubot-datadog-graph": "https://github.com/bouzuya/hubot-datadog-graph/archive/1.1.0.tar.gz",
     "hubot-diagnostics": "0.0.1",
     "hubot-elb": "https://github.com/bouzuya/hubot-elb/archive/1.0.0.tar.gz",
     "hubot-gengo": "https://github.com/bouzuya/hubot-gengo/archive/0.1.1.tar.gz",


### PR DESCRIPTION
https://github.com/bouzuya/hubot-datadog-graph/releases/tag/1.1.0

hubot-datadog-graph を 1.0.0 から 1.1.0 へ。

変更としては `HUBOT_DATADOG_GRAPH_USE_SLACK` オプションで URL の末尾に `#png` を追加できるようになっています。これで Slack で画像が展開されないのを修正しています。