### PR TITLE
bump hubot-datadog-graph to 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "hubot-backlog-status": "https://github.com/bouzuya/hubot-backlog-status/archive/0.1.0.tar.gz",
     "hubot-backlog-summary": "https://github.com/bouzuya/hubot-backlog-summary/archive/0.1.2.tar.gz",
     "hubot-backlog-watch-users": "https://github.com/bouzuya/hubot-backlog-watch-users/archive/1.1.0.tar.gz",
-    "hubot-datadog-graph": "https://github.com/bouzuya/hubot-datadog-graph/archive/1.1.0.tar.gz",
+    "hubot-datadog-graph": "https://github.com/bouzuya/hubot-datadog-graph/archive/2.0.0.tar.gz",
     "hubot-diagnostics": "0.0.1",
     "hubot-elb": "https://github.com/bouzuya/hubot-elb/archive/1.0.0.tar.gz",
     "hubot-gengo": "https://github.com/bouzuya/hubot-gengo/archive/0.1.1.tar.gz",


### PR DESCRIPTION
https://github.com/bouzuya/hubot-datadog-graph/

変更点は以下。

- `hubot datadog graph` を `hubot dd g` と省略できるようにした
- `hubot datadog graph config list` を `hubot datadog graph config` に変更
- `hubot datadog graph <graph> <range>` を `hubot datadog graph <graph> [<range>]` と省略できるように変更 (default: 1h)
- 画像が表示されないことがあるのを改善 wait (default: 1s)
- `<range>` に `mo` を指定できる機能を追加
