### PR TITLE
Add hubot fgb

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,6 @@ A [Hubot][hubot] for [FaithCreates Inc][faithcreates].
     $ export HUBOT_BACKLOG_ACTIVITY_USER_MAPPINGS='{}'
     $ export HUBOT_BACKLOG_ACTIVITY_USE_SLACK='1'
 
-    $ # for hubot-backlog-assign
-    $ HUBOT_BACKLOG_ASSIGN_API_KEY='...'
-    $ HUBOT_BACKLOG_ASSIGN_SPACE_ID='...'
-    $ HUBOT_BACKLOG_ASSIGN_USER_NAMES='...'
-
     $ # for hubot-backlog-burndownchart
     $ HUBOT_BACKLOG_BURNDOWNCHART_API_KEY='...'
     $ HUBOT_BACKLOG_BURNDOWNCHART_PASSWORD='...'

--- a/README.md
+++ b/README.md
@@ -22,10 +22,6 @@ A [Hubot][hubot] for [FaithCreates Inc][faithcreates].
     $ HUBOT_BACKLOG_BURNDOWNCHART_SPACE_ID='...'
     $ HUBOT_BACKLOG_BURNDOWNCHART_USERNAME='...'
 
-    $ # for hubot-backlog-issue-preview
-    $ HUBOT_BACKLOG_ISSUE_PREVIEW_API_KEY='...'
-    $ HUBOT_BACKLOG_ISSUE_PREVIEW_SPACE_ID='...'
-
     $ # for hubot-backlog-report
     $ HUBOT_BACKLOG_REPORT_API_KEY='...'
     $ HUBOT_BACKLOG_REPORT_SPACE_ID='...'

--- a/README.md
+++ b/README.md
@@ -55,6 +55,13 @@ A [Hubot][hubot] for [FaithCreates Inc][faithcreates].
 
     $ # for hubot-diagnostics
 
+    $ # for hubot-fgb
+    $ HUBOT_FGB_BACKLOG_SPACE_ID='...'
+    $ HUBOT_FGB_BACKLOG_USERNAME='...'
+    $ HUBOT_FGB_BACKLOG_API_KEY='...'
+    $ HUBOT_FGB_PROJECTS='...'
+    $ HUBOT_FGB_USERS='...'
+
     $ # for hubot-gengo
 
     $ # for hubot-google-images

--- a/external-scripts.json
+++ b/external-scripts.json
@@ -11,6 +11,7 @@
   "hubot-datadog-graph",
   "hubot-diagnostics",
   "hubot-elb",
+  "hubot-fgb",
   "hubot-gengo",
   "hubot-google-images",
   "hubot-help",

--- a/external-scripts.json
+++ b/external-scripts.json
@@ -1,7 +1,6 @@
 [
   "hubot-auth",
   "hubot-backlog-activity",
-  "hubot-backlog-assign",
   "hubot-backlog-burndownchart",
   "hubot-backlog-issue-preview",
   "hubot-backlog-report",

--- a/external-scripts.json
+++ b/external-scripts.json
@@ -2,7 +2,6 @@
   "hubot-auth",
   "hubot-backlog-activity",
   "hubot-backlog-burndownchart",
-  "hubot-backlog-issue-preview",
   "hubot-backlog-report",
   "hubot-backlog-status",
   "hubot-backlog-summary",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "hubot-auth": "^1.1.2",
     "hubot-backlog-activity": "https://github.com/bouzuya/hubot-backlog-activity/archive/2.0.4.tar.gz",
     "hubot-backlog-burndownchart": "https://github.com/bouzuya/hubot-backlog-burndownchart/archive/1.0.2.tar.gz",
-    "hubot-backlog-issue-preview": "https://github.com/bouzuya/hubot-backlog-issue-preview/archive/2.0.1.tar.gz",
     "hubot-backlog-report": "https://github.com/bouzuya/hubot-backlog-report/archive/2.0.0.tar.gz",
     "hubot-backlog-status": "https://github.com/bouzuya/hubot-backlog-status/archive/0.1.0.tar.gz",
     "hubot-backlog-summary": "https://github.com/bouzuya/hubot-backlog-summary/archive/0.1.2.tar.gz",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "hubot-datadog-graph": "https://github.com/bouzuya/hubot-datadog-graph/archive/2.0.0.tar.gz",
     "hubot-diagnostics": "0.0.1",
     "hubot-elb": "https://github.com/bouzuya/hubot-elb/archive/1.0.0.tar.gz",
+    "hubot-fgb": "https://github.com/faithcreates-tuesday/hubot-fgb/archive/0.2.2.tar.gz",
     "hubot-gengo": "https://github.com/bouzuya/hubot-gengo/archive/0.1.1.tar.gz",
     "hubot-google-images": "^0.1.0",
     "hubot-help": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "hubot": "2.9.3",
     "hubot-auth": "^1.1.2",
     "hubot-backlog-activity": "https://github.com/bouzuya/hubot-backlog-activity/archive/2.0.4.tar.gz",
-    "hubot-backlog-assign": "https://github.com/bouzuya/hubot-backlog-assign/archive/1.1.2.tar.gz",
     "hubot-backlog-burndownchart": "https://github.com/bouzuya/hubot-backlog-burndownchart/archive/1.0.2.tar.gz",
     "hubot-backlog-issue-preview": "https://github.com/bouzuya/hubot-backlog-issue-preview/archive/2.0.1.tar.gz",
     "hubot-backlog-report": "https://github.com/bouzuya/hubot-backlog-report/archive/2.0.0.tar.gz",


### PR DESCRIPTION
hubot-backlog-assign / hubot-backlog-issue-preview を削除し、hubot-fgb を追加します。

`hubot-backlog-assign` によるレビュー依頼コマンドは廃止され、`hubot-fgb` による確認からレビュー依頼できるようになりました。
`hubot-backlog-issue-preview` による Backlog の更新通知は Webhook に変更されました。課題の追加・更新・コメント追加に反応し、その概要を表示します。

旧: 
```
bouzuya> @sushi: review ISSUE-123
```

新:
```
(Backlogが処理済みになった際の Webhook)
sushi  > bouzuya3 が課題「ISSUE-123 summary」を更新したみたい。
         comment
         状態      :  処理中  ->  処理済み
         実績時間  :  未設定  ->  1
         https://space.backlog.jp/view/ISSUE-123
sushi  > @bouzuya ISSUE-123 を誰にレビュー依頼する？

bouzuya> @sushi: @emanon001

sushi  > sushi が課題「ISSUE-123 summary」を更新したみたい。
         レビューをお願いしたいみたい。
         https://github.com/faithcreates/sushi/pull/123 

         担当者    :  bouzuya3 -> emanon001
         https://space.backlog.jp/view/ISSUE-123
```
