### PR TITLE
add hubot-idcf-vm-auto-stop

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,13 @@ A [Hubot][hubot] for [FaithCreates Inc][faithcreates].
     $ HUBOT_IDCF_VM_API_KEY
     $ HUBOT_IDCF_VM_SECRET_KEY
 
+    $ # for hubot-idcf-vm-auto-stop
+    $ HUBOT_IDCF_VM_AUTO_STOP_ENDPOINT
+    $ HUBOT_IDCF_VM_AUTO_STOP_API_KEY
+    $ HUBOT_IDCF_VM_AUTO_STOP_SECRET_KEY
+    $ HUBOT_IDCF_VM_AUTO_STOP_CRON
+    $ HUBOT_IDCF_VM_AUTO_STOP_ROOM
+
     $ # for hubot-lgtm
 
     $ # for hubot-nomulish

--- a/external-scripts.json
+++ b/external-scripts.json
@@ -13,6 +13,7 @@
   "hubot-google-images",
   "hubot-help",
   "hubot-idcf-vm",
+  "hubot-idcf-vm-auto-stop",
   "hubot-lgtm",
   "hubot-nomulish",
   "hubot-omikuji",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "hubot-google-images": "^0.1.0",
     "hubot-help": "^0.1.1",
     "hubot-idcf-vm": "https://github.com/bouzuya/hubot-idcf-vm/archive/1.0.0.tar.gz",
+    "hubot-idcf-vm-auto-stop": "https://github.com/bouzuya/hubot-idcf-vm-auto-stop/archive/1.0.0.tar.gz",
     "hubot-lgtm": "https://github.com/bouzuya/hubot-lgtm/archive/0.1.0.tar.gz",
     "hubot-nomulish": "https://github.com/emanon001/hubot-nomulish/archive/0.1.1.tar.gz",
     "hubot-omikuji": "https://github.com/bouzuya/hubot-omikuji/archive/0.1.0.tar.gz",


### PR DESCRIPTION
IDCF クラウドの特定アカウントの VM すべてを自動で停止する Hubot スクリプトです。